### PR TITLE
feature CAN-7525: add kotlin support and workaround

### DIFF
--- a/lib/fastlane/plugin/rename_android_package/version.rb
+++ b/lib/fastlane/plugin/rename_android_package/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module RenameAndroidPackage
-    VERSION = "0.1.2"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
This PR adds kotlin support and adds workaround mentioned in the comment regarding naming issues related to package names.

how to test:

- Check out this branch
- Replace import in android/fastlane/Pluginfile
Original: gem 'fastlane-plugin-rename_android_package', '>=0.1.1', git: 'https://github.com/livelyhood/fastlane-plugin-rename_android_package'
New: gem 'fastlane-plugin-rename_android_package', path: '<path to fastlane plugin local repo>'

- Run bundle install in mobile android folder.
- Run build yarn android:stg:cove or any android env build script
- Verify `MainAcivity.kt and MainApplication.kt` 'package' name has been replaced with the correct package name that includes the build env.
- Verify that in kotlin file in, the case of cove, that the package name 'is' value is wrapped in `` so kotlin compiler does not mistake for a kotlin reserved word
- Verify that `/Users/sarathregi/Desktop/Cove/Repos/cove-buildings-mobile/android/app/src/main/AndroidManifest.xml`  first line package value has also changed to correct value.
- Verify the namespace value for `/Users/sarathregi/Desktop/Cove/Repos/cove-buildings-mobile/android/app/build.gradle` has also changed
- Try the same with other flavors to see if branding on android works properly
- Please verify that this works on main and main-expo