### PR TITLE
chore: update github token in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ registries:
   npm-npmjs:
     type: npm-registry
     url: https://npm.pkg.github.com
-    token: ${{ secrets.ADMIN_TOKEN_FOR_GITHUB_ACTIONS }}
+    token: ${{ github.token }}
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/dependabot-open-vulnerabilities.yml
+++ b/.github/workflows/dependabot-open-vulnerabilities.yml
@@ -18,7 +18,7 @@ jobs:
           repository: livelyhood/cove-workflows
           ref: ${{ (github.repository == 'livelyhood/cove-workflows' && github.ref) || 'main' }} # IF the this workflow was called from this repo THEN checkout the current github.ref ELSE use main
           path: ./cove-workflows
-          token: ${{ secrets.ADMIN_TOKEN_FOR_GITHUB_ACTIONS }}
+          token: ${{ github.token }}
       - name: read maintainers.json
         id: read-maintainers
         # reads maintainers array and map them to their slack userIds "mentions" (see slack api https://api.slack.com/reference/surfaces/formatting#mentioning-users)
@@ -29,7 +29,7 @@ jobs:
         id: list-vulnerabilities
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ADMIN_TOKEN_FOR_GITHUB_ACTIONS }}
+          github-token: ${{ github.token }}
           script: |
             const script = require('./cove-workflows/src/scripts/dependabot-open-vulnerabilities.js');
             return await script({github, context, core});

--- a/.github/workflows/dependabot-reminder-open-prs.yml
+++ b/.github/workflows/dependabot-reminder-open-prs.yml
@@ -18,7 +18,7 @@ jobs:
           repository: livelyhood/cove-workflows
           ref: ${{ (github.repository == 'livelyhood/cove-workflows' && github.ref) || 'main' }} # IF the this workflow was called from this repo THEN checkout the current github.ref ELSE use main
           path: ./cove-workflows
-          token: ${{ secrets.ADMIN_TOKEN_FOR_GITHUB_ACTIONS }}
+          token: ${{ github.token }}
       - name: read maintainers.json
         id: read-maintainers
         # reads maintainers array and map them to their slack userIds "mentions" (see slack api https://api.slack.com/reference/surfaces/formatting#mentioning-users)
@@ -29,7 +29,7 @@ jobs:
         id: open-dependabot-prs
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ADMIN_TOKEN_FOR_GITHUB_ACTIONS }}
+          github-token: ${{ github.token }}
           script: |
             const script = require('./cove-workflows/src/scripts/dependabot-reminder-open-prs.js');
             return await script({github, context, core});


### PR DESCRIPTION
Replaces `ADMIN_TOKEN_FOR_GITHUB_ACTIONS` with `github.token` in all github workflows