### PR TITLE
chore CAN-15234: replace notify reusable workflow with composite action

### DIFF
--- a/.github/workflows/dependabot-open-vulnerabilities.yml
+++ b/.github/workflows/dependabot-open-vulnerabilities.yml
@@ -72,10 +72,16 @@ jobs:
   #############################################
   notify-all:
   #############################################
-      uses: livelyhood/cove-workflows/.github/workflows/notify.yml@main
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        id-token: write
       needs:
         - dependabot
       if: ${{ always() && contains(needs.*.result, 'failure') }}
-      secrets: inherit
-      with:
-        failure: true
+      steps:
+        - uses: livelyhood/cove-workflows/notify@main
+          with:
+            failure: true
+            oidc-role-arn: ${{ secrets.OIDC_HUB_ROLE_ARN }}
+            secrets-prefix: ${{ vars.GHA_SECRETS_PREFIX }}

--- a/.github/workflows/dependabot-reminder-open-prs.yml
+++ b/.github/workflows/dependabot-reminder-open-prs.yml
@@ -73,10 +73,16 @@ jobs:
   #############################################
   notify-all:
   #############################################
-      uses: livelyhood/cove-workflows/.github/workflows/notify.yml@main
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        id-token: write
       needs:
         - dependabot
       if: ${{ always() && contains(needs.*.result, 'failure') }}
-      secrets: inherit
-      with:
-        failure: true
+      steps:
+        - uses: livelyhood/cove-workflows/notify@main
+          with:
+            failure: true
+            oidc-role-arn: ${{ secrets.OIDC_HUB_ROLE_ARN }}
+            secrets-prefix: ${{ vars.GHA_SECRETS_PREFIX }}


### PR DESCRIPTION
- [x] descriptive short title with jira-number or jira-number in branch name?
- [x] brief description of what this PR changes
- [ ] How To Test written?
- [ ] How To Test pass on review app/env?

---

## Description

Replaces the `notify.yml` reusable workflow with the `notify` composite action in `dependabot-reminder-open-prs.yml` and `dependabot-open-vulnerabilities.yml`.

The reusable workflow at `cove-workflows/.github/workflows/notify.yml` is a thin wrapper around the composite action at `cove-workflows/notify/action.yml`. This migrates callers to use the composite action directly.

Key changes:
- Job-level `uses:` → `runs-on: ubuntu-latest` + step-level composite action
- Permissions updated to `contents: read, id-token: write` (OIDC)
- `secrets: inherit` replaced with explicit `oidc-role-arn` and `secrets-prefix` inputs

## How To Test

Trigger either dependabot workflow manually and verify the notify-all job runs correctly on failure.