### PR TITLE
chore CAN-15234: revert notify composite action change

### DIFF
--- a/.github/workflows/dependabot-open-vulnerabilities.yml
+++ b/.github/workflows/dependabot-open-vulnerabilities.yml
@@ -72,16 +72,10 @@ jobs:
   #############################################
   notify-all:
   #############################################
-      runs-on: ubuntu-latest
-      permissions:
-        contents: read
-        id-token: write
+      uses: livelyhood/cove-workflows/.github/workflows/notify.yml@main
       needs:
         - dependabot
       if: ${{ always() && contains(needs.*.result, 'failure') }}
-      steps:
-        - uses: livelyhood/cove-workflows/notify@main
-          with:
-            failure: true
-            oidc-role-arn: ${{ secrets.OIDC_HUB_ROLE_ARN }}
-            secrets-prefix: ${{ vars.GHA_SECRETS_PREFIX }}
+      secrets: inherit
+      with:
+        failure: true

--- a/.github/workflows/dependabot-reminder-open-prs.yml
+++ b/.github/workflows/dependabot-reminder-open-prs.yml
@@ -73,16 +73,10 @@ jobs:
   #############################################
   notify-all:
   #############################################
-      runs-on: ubuntu-latest
-      permissions:
-        contents: read
-        id-token: write
+      uses: livelyhood/cove-workflows/.github/workflows/notify.yml@main
       needs:
         - dependabot
       if: ${{ always() && contains(needs.*.result, 'failure') }}
-      steps:
-        - uses: livelyhood/cove-workflows/notify@main
-          with:
-            failure: true
-            oidc-role-arn: ${{ secrets.OIDC_HUB_ROLE_ARN }}
-            secrets-prefix: ${{ vars.GHA_SECRETS_PREFIX }}
+      secrets: inherit
+      with:
+        failure: true


### PR DESCRIPTION
- [x] descriptive short title with jira-number or jira-number in branch name?
- [x] brief description of what this PR changes

---

## Description

Reverts #8. This is a public repo — the notify workflow changes should be handled separately as part of a broader review of what workflows belong here.

## How To Test

N/A — restores previous state.