### PR TITLE
chore CAN-16629: migrate all action references to cove-workflows vendor composites

### DIFF
--- a/.github/workflows/dependabot-open-vulnerabilities.yml
+++ b/.github/workflows/dependabot-open-vulnerabilities.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - name: check out current repositories
         # to read maintainers.json
-        uses: actions/checkout@v4
+        uses: livelyhood/cove-workflows/vendors/actions/checkout@main
       - name: check out cove-workflows
         # this is necessary because this workflow gets synced to other repos
-        uses: actions/checkout@v4
+        uses: livelyhood/cove-workflows/vendors/actions/checkout@main
         with:
           repository: livelyhood/cove-workflows
           ref: ${{ (github.repository == 'livelyhood/cove-workflows' && github.ref) || 'main' }} # IF the this workflow was called from this repo THEN checkout the current github.ref ELSE use main

--- a/.github/workflows/dependabot-open-vulnerabilities.yml
+++ b/.github/workflows/dependabot-open-vulnerabilities.yml
@@ -27,7 +27,7 @@ jobs:
           echo "maintainers=$(cat maintainers.json | jq '.[] | to_entries | .[].value' | jq --slurp -r '. | join(" ")')" >> "$GITHUB_OUTPUT"
       - name: query open vulnerability alerts
         id: list-vulnerabilities
-        uses: actions/github-script@v7
+        uses: livelyhood/cove-workflows/vendors/actions/github-script@main
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/dependabot-reminder-open-prs.yml
+++ b/.github/workflows/dependabot-reminder-open-prs.yml
@@ -27,7 +27,7 @@ jobs:
           echo "maintainers=$(cat maintainers.json | jq '.[] | to_entries | .[].value' | jq --slurp -r '. | join(" ")')" >> "$GITHUB_OUTPUT"
       - name: query open dependabot PRs
         id: open-dependabot-prs
-        uses: actions/github-script@v7
+        uses: livelyhood/cove-workflows/vendors/actions/github-script@main
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/dependabot-reminder-open-prs.yml
+++ b/.github/workflows/dependabot-reminder-open-prs.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - name: check out current repositories
         # to read maintainers.json
-        uses: actions/checkout@v4
+        uses: livelyhood/cove-workflows/vendors/actions/checkout@main
       - name: check out cove-workflows
         # this is necessary because this workflow gets synced to other repos
-        uses: actions/checkout@v4
+        uses: livelyhood/cove-workflows/vendors/actions/checkout@main
         with:
           repository: livelyhood/cove-workflows
           ref: ${{ (github.repository == 'livelyhood/cove-workflows' && github.ref) || 'main' }} # IF the this workflow was called from this repo THEN checkout the current github.ref ELSE use main


### PR DESCRIPTION
## Summary\n\nMigrate GitHub Action references to use centralized vendor composites from `livelyhood/cove-workflows`.\n\n### Actions migrated\n- `actions/github-script@v7` → `livelyhood/cove-workflows/vendors/actions/github-script@main`\n\n### Files changed\n- `.github/workflows/dependabot-open-vulnerabilities.yml`\n- `.github/workflows/dependabot-reminder-open-prs.yml`\n\nRef: livelyhood/cove-workflows#360