### PR TITLE
chore CAN-16521: use cove-workflows vendor composites for third-party actions

### DIFF
--- a/.github/workflows/dependabot-open-vulnerabilities.yml
+++ b/.github/workflows/dependabot-open-vulnerabilities.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - name: check out current repositories
         # to read maintainers.json
-        uses: actions/checkout@v4
+        uses: livelyhood/cove-workflows/vendors/actions/checkout@main
       - name: check out cove-workflows
         # this is necessary because this workflow gets synced to other repos
-        uses: actions/checkout@v4
+        uses: livelyhood/cove-workflows/vendors/actions/checkout@main
         with:
           repository: livelyhood/cove-workflows
           ref: ${{ (github.repository == 'livelyhood/cove-workflows' && github.ref) || 'main' }} # IF the this workflow was called from this repo THEN checkout the current github.ref ELSE use main
@@ -27,7 +27,7 @@ jobs:
           echo "maintainers=$(cat maintainers.json | jq '.[] | to_entries | .[].value' | jq --slurp -r '. | join(" ")')" >> "$GITHUB_OUTPUT"
       - name: query open vulnerability alerts
         id: list-vulnerabilities
-        uses: actions/github-script@v7
+        uses: livelyhood/cove-workflows/vendors/actions/github-script@main
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/dependabot-reminder-open-prs.yml
+++ b/.github/workflows/dependabot-reminder-open-prs.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - name: check out current repositories
         # to read maintainers.json
-        uses: actions/checkout@v4
+        uses: livelyhood/cove-workflows/vendors/actions/checkout@main
       - name: check out cove-workflows
         # this is necessary because this workflow gets synced to other repos
-        uses: actions/checkout@v4
+        uses: livelyhood/cove-workflows/vendors/actions/checkout@main
         with:
           repository: livelyhood/cove-workflows
           ref: ${{ (github.repository == 'livelyhood/cove-workflows' && github.ref) || 'main' }} # IF the this workflow was called from this repo THEN checkout the current github.ref ELSE use main
@@ -27,7 +27,7 @@ jobs:
           echo "maintainers=$(cat maintainers.json | jq '.[] | to_entries | .[].value' | jq --slurp -r '. | join(" ")')" >> "$GITHUB_OUTPUT"
       - name: query open dependabot PRs
         id: open-dependabot-prs
-        uses: actions/github-script@v7
+        uses: livelyhood/cove-workflows/vendors/actions/github-script@main
         with:
           github-token: ${{ github.token }}
           script: |


### PR DESCRIPTION
[CAN-16521](https://cove.atlassian.net/browse/CAN-16521)

## Description

Companion fix to [livelyhood/terraform#1223](https://github.com/livelyhood/terraform/pull/1223), which flips `sha_pinning_required = true` org-wide. That change will break any workflow using tag-based third-party action refs (e.g. `actions/checkout@v4`).

Replaces direct `actions/checkout@v4` and `actions/github-script@v7` refs in the two dependabot workflows with the org-standard `livelyhood/cove-workflows/vendors/actions/*@main` composites, consistent with all other repos in the org.

## How-to-Test

- Workflow dispatch either `dependabot-open-vulnerabilities` or `dependabot-reminder-open-prs` and confirm they complete successfully.
- After the terraform PR applies, confirm both workflows still pass (the vendor composite refs are exempt from SHA-pin enforcement as first-party `livelyhood/*` refs).

[CAN-16521]: https://cove.atlassian.net/browse/CAN-16521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ